### PR TITLE
Fix link typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npx nx release
 
 Pass `--dry-run` to see what would happen without actually releasing the library.
 
-[Learn more about Nx release &raquo;](hhttps://nx.dev/features/manage-releases?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+[Learn more about Nx release &raquo;](https://nx.dev/features/manage-releases?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
 
 ## Keep TypeScript project references up to date
 


### PR DESCRIPTION
## Summary
- correct malformed URL `hhttps://` to `https://` in README

## Testing
- `grep -n "hhttps" -n README.md`


------
https://chatgpt.com/codex/tasks/task_e_6844799d61b4832ca7708be55e70f555