### PR TITLE
Fix test describe titles

### DIFF
--- a/packages/mrk/src/lib/makeContext.spec.tsx
+++ b/packages/mrk/src/lib/makeContext.spec.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 
 import { makeContext } from './makeContext';
 
-describe('makeProvider', () => {
+describe('makeContext', () => {
 
     it('should provide values from initializer function', () => {
         const [ Provider, hook ] = makeContext(() => ({

--- a/packages/mrk/src/lib/makeEventHub.spec.tsx
+++ b/packages/mrk/src/lib/makeEventHub.spec.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react';
 
 import { makeEventHub } from './makeEventHub';
 
-describe('makeProvider', () => {
+describe('makeEventHub', () => {
 
     it('should allow parametrized subscribing', () => {
         const [ Provider, useDispatch, useEvent ] = makeEventHub<{


### PR DESCRIPTION
## Summary
- update describe block title in makeContext.spec.tsx
- update describe block title in makeEventHub.spec.tsx

## Testing
- `npx --yes vitest run` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_6844799215dc832c99cd0970e7990230