### PR TITLE
Add context hook error test

### DIFF
--- a/packages/mrk/src/lib/makeContext.spec.tsx
+++ b/packages/mrk/src/lib/makeContext.spec.tsx
@@ -80,4 +80,17 @@ describe('makeProvider', () => {
         expect(queryByText('bar')).toBeTruthy();
     });
 
+    it('should throw if hook used outside provider', () => {
+        const [ , hook ] = makeContext(() => ({
+            foo: 'bar',
+        }));
+
+        const Consumer = () => {
+            hook();
+            return null;
+        };
+
+        expect(() => render(<Consumer/>)).toThrow('Context is null');
+    });
+
 });


### PR DESCRIPTION
## Summary
- test that `makeContext` hook errors when used without provider

## Testing
- `npx nx test @alexkunin/mrk`

------
https://chatgpt.com/codex/tasks/task_e_684479999ce0832c803a5fc735bcbdce