### PR TITLE
Add makeCommand utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.26 (2025-06-07)
+
+* Added `makeCommand` utility for executing async functions with lifecycle events.
+
 ## 0.0.25 (2025-06-07)
 
 This was a version bump only, there were no code changes.

--- a/packages/mk/README.md
+++ b/packages/mk/README.md
@@ -9,3 +9,19 @@ Run `nx build mk` to build the library.
 ## Running unit tests
 
 Run `nx test mk` to execute the unit tests via [Vitest](https://vitest.dev/).
+
+## makeCommand
+
+`makeCommand` wraps an async function and exposes `started`, `completed` and `failed` events using `EventHub`.
+
+```ts
+import { makeCommand } from '@alexkunin/mk';
+
+const increment = makeCommand(async (value: number) => value + 1);
+
+increment.started.subscribe(v => console.log('start', v));
+increment.completed.subscribe(({ result }) => console.log('done', result));
+increment.failed.subscribe(({ error }) => console.error(error));
+
+await increment(1);
+```

--- a/packages/mk/src/index.ts
+++ b/packages/mk/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/EventHub';
 export * from './lib/makeContainer';
+export * from './lib/makeCommand';

--- a/packages/mk/src/lib/makeCommand.spec.ts
+++ b/packages/mk/src/lib/makeCommand.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { makeCommand } from './makeCommand';
+
+function createRecorder() {
+    const order: string[] = [];
+    return {
+        order,
+        push: (label: string) => () => order.push(label),
+    };
+}
+
+describe('makeCommand', () => {
+    it('dispatches started then completed', async () => {
+        const record = createRecorder();
+        const command = makeCommand(async (n: number) => {
+            record.push('handler')();
+            return n + 1;
+        });
+
+        command.started.subscribe(record.push('started'));
+        command.completed.subscribe(record.push('completed'));
+
+        await command(1);
+
+        expect(record.order).toEqual(['started', 'handler', 'completed']);
+    });
+
+    it('dispatches started then failed', async () => {
+        const record = createRecorder();
+        const command = makeCommand(async () => {
+            record.push('handler')();
+            throw new Error('boom');
+        });
+
+        command.started.subscribe(record.push('started'));
+        command.failed.subscribe(record.push('failed'));
+
+        await expect(command(undefined as never)).rejects.toThrow('boom');
+        expect(record.order).toEqual(['started', 'handler', 'failed']);
+    });
+});

--- a/packages/mk/src/lib/makeCommand.ts
+++ b/packages/mk/src/lib/makeCommand.ts
@@ -1,0 +1,31 @@
+import { EventHub } from './EventHub';
+
+export interface Command<I, O> {
+    (input: I): Promise<O>;
+    readonly started: EventHub<I>;
+    readonly completed: EventHub<{ input: I; result: O }>;
+    readonly failed: EventHub<{ input: I; error: unknown }>;
+}
+
+export function makeCommand<I, O>(
+    handler: (input: I) => Promise<O> | O,
+): Command<I, O> {
+    const target = new EventTarget();
+    const started = new EventHub<I>('started', undefined, target);
+    const completed = new EventHub<{ input: I; result: O }>('completed', undefined, target);
+    const failed = new EventHub<{ input: I; error: unknown }>('failed', undefined, target);
+
+    async function command(input: I): Promise<O> {
+        started.dispatch(input);
+        try {
+            const result = await handler(input);
+            completed.dispatch({ input, result });
+            return result;
+        } catch (error) {
+            failed.dispatch({ input, error });
+            throw error;
+        }
+    }
+
+    return Object.assign(command, { started, completed, failed });
+}


### PR DESCRIPTION
## Summary
- implement `makeCommand` based on `EventHub`
- export the new API from the library entrypoint
- test command event dispatch order
- document `makeCommand` usage
- record change in `CHANGELOG`

## Testing
- `npx -y nx build mk`
- `npx -y nx test mk`

------
https://chatgpt.com/codex/tasks/task_e_684486697548832c9c8073fdf2128727