### PR TITLE
Fix README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Alexkunin Monorepo
 
-This repository contains a small collection of TypeScript packages. Each package lives under the `packages/` directory and exposes a set of utilities with their own documentation.
+This repository contains a small collection of TypeScript packages. Each package
+lives under the `packages/` directory and exposes a set of utilities with its
+own documentation.
 
 ## Packages
 
-- [@alexkunin/mk](packages/mk/README.md) – utilities such as `EventHub`, `makeContainer` and `makeCommand`.
-- [@alexkunin/mrk](packages/mrk/README.md) – React specific helpers built on top of `@alexkunin/mk`.
+- [@alexkunin/mk](packages/mk/README.md) – utilities such as `EventHub`,
+  `makeContainer` and `makeCommand`.
+- [@alexkunin/mrk](packages/mrk/README.md) – React specific helpers built on top
+  of `@alexkunin/mk`.
 
 Visit each package README for details and usage examples.
+

--- a/packages/mk/src/eventHub/README.md
+++ b/packages/mk/src/eventHub/README.md
@@ -7,7 +7,7 @@ Simple wrapper over `EventTarget` providing typed events.
 ```ts
 import { EventHub } from '@alexkunin/mk';
 
-const hub = new EventHub<'string'>('my-event');
+const hub = new EventHub<string>('my-event');
 
 const unsubscribe = hub.subscribe(data => console.log(data));
 

--- a/packages/mrk/src/makeContext/README.md
+++ b/packages/mrk/src/makeContext/README.md
@@ -9,9 +9,13 @@ import { makeContext } from '@alexkunin/mrk';
 
 const [ Provider, useCtx ] = makeContext(() => ({ value: 'foo' }));
 
-<Provider>
-  <Child />
-</Provider>
+function App() {
+  return (
+    <Provider>
+      <Child />
+    </Provider>
+  );
+}
 
 function Child() {
   const ctx = useCtx();

--- a/packages/mrk/src/makeEventHub/README.md
+++ b/packages/mrk/src/makeEventHub/README.md
@@ -11,9 +11,18 @@ const [ Provider, useDispatch, useEvent ] = makeEventHub<{
   ping: string;
 }>();
 
+function App() {
+  return (
+    <Provider>
+      <Sender />
+      <Listener />
+    </Provider>
+  );
+}
+
 function Sender() {
   const dispatch = useDispatch();
-  return <button onClick={() => dispatch('ping', 'pong')}/>;
+  return <button onClick={() => dispatch('ping', 'pong')} />;
 }
 
 function Listener() {


### PR DESCRIPTION
## Summary
- tweak root README formatting
- fix EventHub generic
- complete React usage examples

## Testing
- `npx vitest run` *(fails: needs interactive package install)*

------
https://chatgpt.com/codex/tasks/task_e_684536de4dc0832cbc43f28fc0b863ae